### PR TITLE
Big Fix: Array bounds crash in key handling

### DIFF
--- a/src/applicationInternal/keys.cpp
+++ b/src/applicationInternal/keys.cpp
@@ -40,26 +40,57 @@ unsigned long lastTimeSent[keypadROWS][keypadCOLS] ={
   {0, 0, 0, 0, 0},
 };
 
+bool isKeyPressInBounds(int keyCode, int& row, int& col) {
+  row = keyCode / keypadCOLS;
+  col = keyCode % keypadCOLS;
+  
+  if (row >= keypadROWS || col >= keypadCOLS) {
+    omote_log_e("doShortPress: keyCode %d results in invalid row=%d, col=%d (max: %d, %d)\n", 
+                keyCode, row, col, keypadROWS-1, keypadCOLS-1);
+    return false;
+  }
+  return true;
+}
+
+bool isKeyPressRateLimited(int row, int col, unsigned long currentMillis) {
+  return (currentMillis - lastTimeSent[row][col]) <= repeatRate;
+}
+
 void doShortPress(char keyChar, int keyCode){
   unsigned long currentMillis = millis();
-  if ((currentMillis - lastTimeSent[keyCode/keypadROWS][keyCode%keypadROWS]) > repeatRate) {
-    lastTimeSent[keyCode/keypadROWS][keyCode%keypadROWS] = currentMillis;
-
-    uint16_t command = get_command_short(gui_memoryOptimizer_getActiveSceneName(), keyChar);
-    if (command != COMMAND_UNKNOWN) {
-      omote_log_d("key: key '%c', will use command '%u'\r\n", keyChar, command);
-      executeCommand(command);
-    } else {
-      omote_log_w("key: key '%c', but no command defined\r\n", keyChar);
-    }
+  int row, col;
+  
+  if (!isKeyPressInBounds(keyCode, row, col)) {
+    return;
   }
+  
+  if (isKeyPressRateLimited(row, col, currentMillis)) {
+    return;
+  }
+  
+  lastTimeSent[row][col] = currentMillis;
+
+  uint16_t command = get_command_short(gui_memoryOptimizer_getActiveSceneName(), keyChar);
+  if (command == COMMAND_UNKNOWN) {
+    omote_log_w("key: key '%c', but no command defined\r\n", keyChar);
+    return;
+  }
+  
+  omote_log_d("key: key '%c', will use command '%u'\r\n", keyChar, command);
+  CommandExecutionParams params;
+  params.commandId = command;
+  params.commandType = CMD_SHORT;
+  executeCommand(params);
 }
 
 void doLongPress(char keyChar, int keyCode){
   uint16_t command = get_command_long(gui_memoryOptimizer_getActiveSceneName(), keyChar);
   if (command != COMMAND_UNKNOWN) {
     omote_log_d("key: key '%c' (long press), will use command '%u'\r\n", keyChar, command);
-    executeCommand(command);
+    CommandExecutionParams params;
+    params.commandId = command;
+    params.commandType = CMD_LONG;
+    executeCommand(params);
   } else {
     omote_log_w("key: key '%c' (long press), but no command defined\r\n", keyChar);
   }
@@ -112,7 +143,7 @@ void keypad_processKeyStates() {
 
       keypad_keyStates singleKeyState = keyState[row][col];
       char keyChar = rawKeys[row][col].keyChar;
-      int keyCode = row * keypadROWS + col;
+      int keyCode = row * keypadCOLS + col;
 
       if (singleKeyState == PRESSED) {
         omote_log_v("pressed\r\n");

--- a/src/applicationInternal/keys.cpp
+++ b/src/applicationInternal/keys.cpp
@@ -77,20 +77,14 @@ void doShortPress(char keyChar, int keyCode){
   }
   
   omote_log_d("key: key '%c', will use command '%u'\r\n", keyChar, command);
-  CommandExecutionParams params;
-  params.commandId = command;
-  params.commandType = CMD_SHORT;
-  executeCommand(params);
+  executeCommand(command);
 }
 
 void doLongPress(char keyChar, int keyCode){
   uint16_t command = get_command_long(gui_memoryOptimizer_getActiveSceneName(), keyChar);
   if (command != COMMAND_UNKNOWN) {
     omote_log_d("key: key '%c' (long press), will use command '%u'\r\n", keyChar, command);
-    CommandExecutionParams params;
-    params.commandId = command;
-    params.commandType = CMD_LONG;
-    executeCommand(params);
+    executeCommand(command);
   } else {
     omote_log_w("key: key '%c' (long press), but no command defined\r\n", keyChar);
   }


### PR DESCRIPTION
I was encountering intermittent crashes when my kids were using the remote. This led me to debugging the crashes and I uncovered 3 issues along the way. This was the 1st issue.

### Problem: 
LoadProhibited crash with `EXCVADDR: 0x00000009` when pressing `KEY_CHUP` repeatedly, caused by array bounds violations in key handling code.

### Root Cause:
- Incorrect array indexing in `doShortPress()` : `lastTimeSent[keyCode/keypadROWS][keyCode%keypadROWS]`.
- Wrong `keyCode` calculation in `keypad_processKeyStates()`: `row * keypadROWS + col` instead of `row * keypadCOLS + col`.

### Proposed Fix:
1. Corrected array indexing to use proper row/col derivation.
2. Fixed `keyCode` calculation.
3. Added bounds checking with helper functions to improve readability `isKeyPressInBounds()` and `isKeyPressRateLimited()`.
4. Refactored nested conditionals with early returns, defensive programming.