### PR TITLE
Bug Fix: Add safe LVGL object deletion to prevent LoadProhibited crashes

### DIFF
--- a/src/applicationInternal/gui/guiBase.cpp
+++ b/src/applicationInternal/gui/guiBase.cpp
@@ -350,6 +350,18 @@ void guis_doTabCreationForNavigateToLastActiveGUIofPreviousGUIlist() {
 // ------------------------------------------------------------------------------------------------------------
 
 void setActiveTab(uint32_t index, lv_anim_enable_t anim_en, bool send_tab_changed_event) {
+  // Check if tabview is initialized before using it
+  if (tabview == NULL) {
+    omote_log_w("setActiveTab: tabview is NULL, cannot set active tab\n");
+    return;
+  }
+  
+  // Check if the tabview object is still valid
+  if (!lv_obj_is_valid(tabview)) {
+    omote_log_w("setActiveTab: tabview object is invalid, cannot set active tab\n");
+    return;
+  }
+  
   // unsigned long startTime = millis();
   if (anim_en == LV_ANIM_ON) {
     lv_tabview_set_act(tabview, index, LV_ANIM_ON);

--- a/src/applicationInternal/gui/guiMemoryOptimizer.cpp
+++ b/src/applicationInternal/gui/guiMemoryOptimizer.cpp
@@ -108,15 +108,35 @@ void notify_active_tabs_before_delete(t_gui_state *gui_state) {
   }
 }
 
-void clear_tabview(lv_obj_t* tabview, t_gui_state *gui_state) {
-  if (tabview != NULL) {
-    // first remove events for the tabview
-    lv_obj_remove_event_cb(tabview, tabview_tab_changed_event_cb);
-    lv_obj_remove_event_cb(tabview, tabview_content_is_scrolling_event_cb);
-    // delete tabview
-    lv_obj_del(tabview);
-    tabview = NULL;
+void safe_delete_lv_obj(lv_obj_t* obj, const char* obj_name) {
+  if (obj == NULL) {
+    return;
   }
+  
+  if (!lv_obj_is_valid(obj)) {
+    omote_log_w("safe_delete_lv_obj: %s object is invalid, skipping deletion\n", obj_name);
+    return;
+  }
+  
+  lv_obj_del(obj);
+}
+
+void clear_tabview(lv_obj_t* tabview, t_gui_state *gui_state) {
+  if (tabview == NULL) {
+    return;
+  }
+  
+  if (!lv_obj_is_valid(tabview)) {
+    omote_log_w("clear_tabview: tabview object is invalid, skipping deletion\n");
+    return;
+  }
+  
+  // first remove events for the tabview
+  lv_obj_remove_event_cb(tabview, tabview_tab_changed_event_cb);
+  lv_obj_remove_event_cb(tabview, tabview_content_is_scrolling_event_cb);
+  // delete tabview
+  lv_obj_del(tabview);
+  tabview = NULL;
 
   // the gui_list_index_previous is needed for setGUIlistIndicesToBeShown_afterSlide();
   gui_state->gui_on_tab[0] = {NULL, "", -1, gui_state->gui_on_tab[0].gui_list_index};
@@ -126,19 +146,9 @@ void clear_tabview(lv_obj_t* tabview, t_gui_state *gui_state) {
 }
 
 void clear_panel(lv_obj_t* panel, lv_obj_t* img1, lv_obj_t* img2) {
-  if (panel != NULL) {
-    lv_obj_del(panel);
-    panel = NULL;
-  }
-  if (img1 != NULL) {
-    lv_obj_del(img1);
-    img1 = NULL;
-  } 
-  if (img2 != NULL) {
-    lv_obj_del(img2);
-    img2 = NULL;
-  } 
-
+  safe_delete_lv_obj(panel, "panel");
+  safe_delete_lv_obj(img1, "img1");
+  safe_delete_lv_obj(img2, "img2");
 }
 
 lv_obj_t* create_tabview() {
@@ -318,6 +328,17 @@ void fillPanelWithPageIndicator_strategyMax3(lv_obj_t* panel, lv_obj_t* img1, lv
     #endif
     return;
   }
+  
+  // Check available memory before creating many objects
+  size_t free_heap = esp_get_free_heap_size();
+  if (free_heap < 5000) { // Less than 5KB free
+    omote_log_w("fillPanelWithPageIndicator: Low memory (%zu bytes), skipping page indicators\n", free_heap);
+    lv_obj_add_style(panel, &panel_style, 0);
+    #ifdef drawRedBorderAroundMainWidgets
+    lv_obj_add_style(panel, &style_red_border, LV_PART_MAIN);
+    #endif
+    return;
+  }
 
   // This small hidden button enables the page indicator to scroll further
   lv_obj_t* btn = lv_btn_create(panel);
@@ -409,8 +430,14 @@ void fillPanelWithPageIndicator_strategyMax3(lv_obj_t* panel, lv_obj_t* img1, lv
       // create a breadcrump dot for each gui in the main_gui_list
       for (int j=0; j<breadcrumpMainGuiListLength; j++) {
         lv_obj_t* dot = lv_obj_create(btn);
+        if (dot == NULL) {
+          omote_log_e("fillPanelWithPageIndicator: Failed to create dot object, out of memory\n");
+          continue;
+        }
+        
         lv_obj_set_size(dot, breadcrumpDotSize, breadcrumpDotSize);
         lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, LV_PART_MAIN);
+        
         // hightlight dot if it is the one for the currently active tab
         #if (USE_SCENE_SPECIFIC_GUI_LIST != 0)
         if ( ((gui_memoryOptimizer_getActiveGUIlist() == MAIN_GUI_LIST) || !get_scene_has_gui_list(gui_memoryOptimizer_getActiveSceneName()))
@@ -437,6 +464,11 @@ void fillPanelWithPageIndicator_strategyMax3(lv_obj_t* panel, lv_obj_t* img1, lv
       if (show_scene_gui_list) {
       for (int j=0; j<breadcrumpSceneGuiListLength; j++) {
         lv_obj_t* dot = lv_obj_create(btn);
+        if (dot == NULL) {
+          omote_log_e("fillPanelWithPageIndicator: Failed to create scene dot object, out of memory\n");
+          continue;
+        }
+        
         lv_obj_set_size(dot, breadcrumpDotSize, breadcrumpDotSize);
         lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, LV_PART_MAIN);
         if ((gui_memoryOptimizer_getActiveGUIlist() == SCENE_GUI_LIST) && (j == (breadcrumpPosition-1))) {

--- a/src/applicationInternal/gui/guiMemoryOptimizer.cpp
+++ b/src/applicationInternal/gui/guiMemoryOptimizer.cpp
@@ -330,9 +330,10 @@ void fillPanelWithPageIndicator_strategyMax3(lv_obj_t* panel, lv_obj_t* img1, lv
   }
   
   // Check available memory before creating many objects
-  size_t free_heap = esp_get_free_heap_size();
-  if (free_heap < 5000) { // Less than 5KB free
-    omote_log_w("fillPanelWithPageIndicator: Low memory (%zu bytes), skipping page indicators\n", free_heap);
+  unsigned long heapSize, freeHeap, maxAllocHeap, minFreeHeap;
+  get_heapUsage(&heapSize, &freeHeap, &maxAllocHeap, &minFreeHeap);
+  if (freeHeap < 5000) { // Less than 5KB free
+    omote_log_w("fillPanelWithPageIndicator: Low memory (%lu bytes), skipping page indicators\n", freeHeap);
     lv_obj_add_style(panel, &panel_style, 0);
     #ifdef drawRedBorderAroundMainWidgets
     lv_obj_add_style(panel, &style_red_border, LV_PART_MAIN);


### PR DESCRIPTION
I was encountering intermittent crashes when my kids were using the remote. This led me to debugging the crashes and I uncovered 3 issues along the way. This was the 2nd issue.

### Problem: 
LoadProhibited crash with `EXCVADDR: 0x00000009` when pressing `KEY_RIGHT` repeatedly in default scene, caused by invalid LVGL object access during GUI navigation.

### Root Cause:
- `setActiveTab()` function called LVGL functions on potentially NULL or invalid tabview objects.
- `clear_tabview()` and `clear_panel()` deleted objects without validation.
- Possible race conditions between object deletion and usage.

### Fix:
1. Added `safe_delete_lv_obj()` helper function to validate objects before deletion.
2. Added null and validity checks in `setActiveTab()` before using tabview.
3. Refactored `clear_tabview()` and `clear_panel()` to use safe deletion with early returns.
4. Prevents LoadProhibited crashes from invalid LVGL object access.